### PR TITLE
Fix taxonomy check for kingdom in training script

### DIFF
--- a/funannotate2/train.py
+++ b/funannotate2/train.py
@@ -350,7 +350,7 @@ def train(args):
     if which_path("gmes_petap.pl") and which_path("gmhmme3"):
         logger.info(f"Training GeneMark-ES using {args.genemark_mode} mode")
         fungus_flag = False
-        if taxonomy["kingdom"] == "Fungi":
+        if taxonomy and taxonomy.get("kingdom") == "Fungi":
             fungus_flag = True
         genemark_train = train_genemark(
             TrainingGenomeFasta,


### PR DESCRIPTION
First time doing pull requests so don't get angry at me if something is wrong with the submission :) 

### Minor fix to sometimes absent “kingdom” flag & TypeError related to non-searchable NCBI species names.

**non-searchable NCBI species names:** for custom names runs were resulting in `TypeError`:
```
funannotate2/train.py", line 353, in train
    if taxonomy["kingdom"] == "Fungi":
TypeError: 'bool' object is not subscriptable
```
**absent “kingdom” flag:** for some species (like Paramoeba/Perkinsela) kingdom key can be absent, resulting in `KeyError: 'kingdom'`:
{
  "superkingdom": "Eukaryota",
  "phylum": "Discosea",
  ...
}
{
  "superkingdom": "Eukaryota",
  "phylum": "Euglenozoa",
  ...
}