### PR TITLE
Respect --tmpdir across annotate (diamond) and predict (miniprot) steps

### DIFF
--- a/funannotate2/align.py
+++ b/funannotate2/align.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 import uuid
 
 from gapmm2.align import aligner as transcript_aligner
@@ -66,7 +67,7 @@ def align_transcripts(
     cpus=1,
     max_intron=3000,
     log=sys.stderr.write,
-    tmpdir="/tmp",
+    tmpdir=None,
 ):
     """
     Run spliced transcript alignment using gapmm2 (mm2 + edlib refinement).
@@ -82,7 +83,7 @@ def align_transcripts(
         cpus (int, optional): Number of CPUs to use for alignment. Defaults to 1.
         max_intron (int, optional): Maximum intron length allowed. Defaults to 3000.
         log (function, optional): Logging function. Defaults to sys.stderr.write.
-        tmpdir (str, optional): Temporary directory path. Defaults to "/tmp".
+        tmpdir (str, optional): Accepted for API parity with ``align_proteins``; currently unused because the gapmm2 backend writes directly to ``output=evidence``. Defaults to ``None`` (resolves to ``tempfile.gettempdir()`` when relied upon).
     """
     # function to run spliced transcript alignment using gapmm2 (mm2 + edlib refinement)
     # generate an EVM compatible GFF alignment file, parse data and pull out any full length gene models
@@ -114,7 +115,7 @@ def align_proteins(
     cpus=1,
     max_intron=3000,
     log=sys.stderr.write,
-    tmpdir="/tmp",
+    tmpdir=None,
 ):
     """
     Align protein evidence to the genome assembly using miniprot.
@@ -129,13 +130,15 @@ def align_proteins(
         cpus (int, optional): Number of CPUs to use for alignment. Defaults to 1.
         max_intron (int, optional): Maximum intron length for alignment. Defaults to 3000.
         log (function, optional): Logger function for info and error messages. Defaults to sys.stderr.write.
-        tmpdir (str, optional): Temporary directory path for storing intermediate files. Defaults to "/tmp".
+        tmpdir (str, optional): Temporary directory path for storing intermediate files. Defaults to the system temporary directory (``tempfile.gettempdir()``), which honors ``$TMPDIR``.
 
     Returns:
         None
     """
     # function to align protein evidence to genome with miniprot
     # generate evidence alignments and then parse any full length models
+    if tmpdir is None:
+        tmpdir = tempfile.gettempdir()
     mini_tmp = os.path.join(tmpdir, f"{uuid.uuid1()}.miniprot.out")
     # miniprot --outn=4 --gff-only -t 8 valid_contigs.fasta /usr/local/share/funannotate/uniprot_sprot.fasta > uniprot.mini.gff3
     log.info("Aligning protein evidence to the genome assembly with miniprot")

--- a/funannotate2/annotate.py
+++ b/funannotate2/annotate.py
@@ -310,7 +310,7 @@ def annotate(args):
             "Annotating proteome with diamond against the UniProtKB/Swiss-Prot database"
         )
         start = time.time()
-        swiss = swissprot_blast(Proteins, cpus=args.cpus)
+        swiss = swissprot_blast(Proteins, cpus=args.cpus, tmpdir=tmp_dir)
         end = time.time()
         logger.info(
             f"UniProtKB/Swiss-Prot search resulted in {len(swiss)} hits and finished in {round(end - start, 2)} seconds"
@@ -330,7 +330,7 @@ def annotate(args):
             "Annotating proteome with diamond against the MEROPS protease database"
         )
         start = time.time()
-        merops = merops_blast(Proteins, cpus=args.cpus)
+        merops = merops_blast(Proteins, cpus=args.cpus, tmpdir=tmp_dir)
         end = time.time()
         logger.info(
             f"MEROPS search resulted in {len(merops)} hits and finished in {round(end - start, 2)} seconds"

--- a/funannotate2/predict.py
+++ b/funannotate2/predict.py
@@ -271,6 +271,7 @@ def predict(args):
             cpus=args.cpus,
             max_intron=args.max_intron,
             log=logger,
+            tmpdir=tmp_dir,
         )
     elif checkfile(TranAlign) and checkfile(TranGenes):
         log("Existing transcript alignments found, will re-use and continue")
@@ -304,6 +305,7 @@ def predict(args):
             cpus=args.cpus,
             max_intron=args.max_intron,
             log=logger,
+            tmpdir=tmp_dir,
         )
     elif checkfile(ProtAlign) and checkfile(ProtGenes):
         log("Existing protein alignments found, will re-use and continue")

--- a/funannotate2/search.py
+++ b/funannotate2/search.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import uuid
 
 import json_repair
@@ -316,7 +317,7 @@ def dbcan2tsv(results, output, annots):
     return a
 
 
-def diamond_blast(db, query, cpus=1, evalue=10.0, max_target_seqs=1, tmpdir="/tmp"):
+def diamond_blast(db, query, cpus=1, evalue=10.0, max_target_seqs=1, tmpdir=None):
     """
     Run a protein BLAST using Diamond.
 
@@ -328,12 +329,14 @@ def diamond_blast(db, query, cpus=1, evalue=10.0, max_target_seqs=1, tmpdir="/tm
         cpus (int, optional): Number of CPUs to use. Defaults to 1.
         evalue (float, optional): E-value threshold. Defaults to 10.0.
         max_target_seqs (int, optional): Maximum number of target sequences to report. Defaults to 1.
-        tmpdir (str, optional): Temporary directory to store intermediate files. Defaults to "/tmp".
+        tmpdir (str, optional): Temporary directory to store intermediate files. Defaults to the system temporary directory (``tempfile.gettempdir()``), which honors ``$TMPDIR``.
 
     Returns:
         list: JSON formatted results of the BLAST search.
     """
     # use diamond as protein blast
+    if tmpdir is None:
+        tmpdir = tempfile.gettempdir()
     tmpfile = os.path.join(tmpdir, f"diamond_{uuid.uuid4()}")
     cmd = [
         "diamond",
@@ -377,7 +380,7 @@ def diamond_blast(db, query, cpus=1, evalue=10.0, max_target_seqs=1, tmpdir="/tm
     return results
 
 
-def merops_blast(query, evalue=1e-5, cpus=1, max_target_seqs=1):
+def merops_blast(query, evalue=1e-5, cpus=1, max_target_seqs=1, tmpdir=None):
     """
     Run a BLAST search against the MEROPS database using Diamond.
 
@@ -388,6 +391,7 @@ def merops_blast(query, evalue=1e-5, cpus=1, max_target_seqs=1):
         evalue (float, optional): E-value threshold for reporting hits. Defaults to 1e-5.
         cpus (int, optional): Number of CPUs to use. Defaults to 1.
         max_target_seqs (int, optional): Maximum number of target sequences to report. Defaults to 1.
+        tmpdir (str, optional): Temporary directory forwarded to ``diamond_blast`` for intermediate files. Defaults to the system temporary directory.
 
     Returns:
         list: A list of dictionaries containing information about the hits found, including coverage and family details.
@@ -397,7 +401,12 @@ def merops_blast(query, evalue=1e-5, cpus=1, max_target_seqs=1):
     if checkfile(merops_db):
         results = []
         raw_results = diamond_blast(
-            merops_db, query, cpus=cpus, evalue=evalue, max_target_seqs=max_target_seqs
+            merops_db,
+            query,
+            cpus=cpus,
+            evalue=evalue,
+            max_target_seqs=max_target_seqs,
+            tmpdir=tmpdir,
         )
         for res in raw_results:
             coverage = (res["length"] / res["qlen"]) * 100
@@ -440,7 +449,13 @@ def merops2tsv(results, output, annots):
 
 
 def swissprot_blast(
-    query, evalue=1e-5, cpus=1, min_pident=60, min_cov=60, max_target_seqs=1
+    query,
+    evalue=1e-5,
+    cpus=1,
+    min_pident=60,
+    min_cov=60,
+    max_target_seqs=1,
+    tmpdir=None,
 ):
     """
     Perform a BLAST search against the SwissProt database using Diamond.
@@ -454,6 +469,7 @@ def swissprot_blast(
         min_pident (int, optional): Minimum percentage identity required for a hit. Defaults to 60.
         min_cov (int, optional): Minimum coverage percentage required for a hit. Defaults to 60.
         max_target_seqs (int, optional): Maximum number of target sequences to report. Defaults to 1.
+        tmpdir (str, optional): Temporary directory forwarded to ``diamond_blast`` for intermediate files. Defaults to the system temporary directory.
 
     Returns:
         list: A list of dictionaries containing information about the filtered hits, including coverage, percentage identity, and alignment details.
@@ -463,7 +479,12 @@ def swissprot_blast(
     if checkfile(uniprot_db):
         results = []
         raw_results = diamond_blast(
-            uniprot_db, query, cpus=cpus, evalue=evalue, max_target_seqs=max_target_seqs
+            uniprot_db,
+            query,
+            cpus=cpus,
+            evalue=evalue,
+            max_target_seqs=max_target_seqs,
+            tmpdir=tmpdir,
         )
         for res in raw_results:
             if res["pident"] >= min_pident:

--- a/funannotate2/utilities.py
+++ b/funannotate2/utilities.py
@@ -9,6 +9,7 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 import uuid
@@ -531,32 +532,27 @@ def human_readable_size(size, decimal_places=2):
 
 def create_tmpdir(outdir, base="predict"):
     """
-    Create a temporary directory for storing files.
+    Create a unique temporary directory for storing intermediate files.
 
-    This function generates a temporary directory with a unique name based on the provided
-    base name and a UUID. If an output directory is specified, the temporary directory is
-    created within it. If the output directory is "/tmp", a subdirectory is created; otherwise,
-    the specified directory is used directly. If no output directory is provided, the temporary
-    directory is created in the current working directory.
+    A ``<base>_<uuid>`` subdirectory is always created inside the supplied
+    volume (``outdir``). If ``outdir`` is falsy, the system temporary directory
+    (``tempfile.gettempdir()``, which honors the ``$TMPDIR`` environment
+    variable) is used as the parent. Using a unique subdirectory avoids
+    collisions between concurrent runs sharing a scratch volume and prevents
+    downstream cleanup from inadvertently removing a user-supplied directory.
 
     Parameters:
-    - outdir (str): The output directory path.
+    - outdir (str or None): The parent directory under which the unique tmpdir
+      will be created. If falsy, ``tempfile.gettempdir()`` is used.
     - base (str, optional): The base name for the temporary directory (default is "predict").
 
     Returns:
     - str: The absolute path of the created temporary directory.
     """
-    # create a tmpdir for some files
     tmpdirslug = "{}_{}".format(base, str(uuid.uuid4()))
-    if outdir:
-        if outdir == "/tmp":
-            tmpdir = os.path.join(outdir, tmpdirslug)
-        else:
-            tmpdir = outdir
-    else:
-        tmpdir = tmpdirslug
-    if not os.path.isdir(tmpdir):
-        os.makedirs(tmpdir)
+    parent = outdir if outdir else tempfile.gettempdir()
+    tmpdir = os.path.join(parent, tmpdirslug)
+    os.makedirs(tmpdir, exist_ok=True)
     return os.path.abspath(tmpdir)
 
 

--- a/tests/unit/test_predict.py
+++ b/tests/unit/test_predict.py
@@ -317,3 +317,73 @@ class TestPredict:
         assert not any("memory prediction for scaffold_1.fasta" in message for message in debug_messages)
         assert stats["tools_run"] == ["snap"]
         assert stats["contig_length"] == 4
+
+
+
+class TestAlignProteinsTmpdir:
+    """Tests verifying align_proteins honors the tmpdir kwarg (issue #52 follow-up)."""
+
+    def _capture_stdout_path(self):
+        captured = {}
+
+        def fake_run_subprocess(cmd, log, stdout=None, **kwargs):
+            captured["stdout"] = stdout
+            captured["cmd"] = cmd
+            return 0
+
+        return captured, fake_run_subprocess
+
+    @patch("funannotate2.align.os.remove")
+    @patch("funannotate2.align.split_evidence_and_genes")
+    @patch("funannotate2.align.runSubprocess")
+    def test_align_proteins_uses_provided_tmpdir(
+        self, mock_run_subprocess, mock_split, mock_remove, tmp_path
+    ):
+        from funannotate2.align import align_proteins
+
+        captured, fake = self._capture_stdout_path()
+        mock_run_subprocess.side_effect = fake
+        mock_split.return_value = (0, 0)
+
+        logger = MagicMock()
+        align_proteins(
+            "genome.fasta",
+            "proteins.fasta",
+            "evidence.gff3",
+            "genes.gff3",
+            cpus=1,
+            log=logger,
+            tmpdir=str(tmp_path),
+        )
+
+        assert captured["stdout"] is not None
+        assert captured["stdout"].startswith(str(tmp_path) + os.sep)
+        assert captured["stdout"].endswith(".miniprot.out")
+
+    @patch("funannotate2.align.os.remove")
+    @patch("funannotate2.align.split_evidence_and_genes")
+    @patch("funannotate2.align.runSubprocess")
+    def test_align_proteins_defaults_to_system_tmp(
+        self, mock_run_subprocess, mock_split, mock_remove
+    ):
+        import tempfile
+
+        from funannotate2.align import align_proteins
+
+        captured, fake = self._capture_stdout_path()
+        mock_run_subprocess.side_effect = fake
+        mock_split.return_value = (0, 0)
+
+        logger = MagicMock()
+        align_proteins(
+            "genome.fasta",
+            "proteins.fasta",
+            "evidence.gff3",
+            "genes.gff3",
+            cpus=1,
+            log=logger,
+        )
+
+        assert captured["stdout"] is not None
+        assert captured["stdout"].startswith(tempfile.gettempdir() + os.sep)
+        assert captured["stdout"].endswith(".miniprot.out")

--- a/tests/unit/test_search_comprehensive.py
+++ b/tests/unit/test_search_comprehensive.py
@@ -191,6 +191,7 @@ class TestSearchComprehensive:
             cpus=1,
             evalue=1e-5,
             max_target_seqs=1,
+            tmpdir=None,
         )
 
     @patch("funannotate2.search.env")
@@ -246,6 +247,7 @@ class TestSearchComprehensive:
             cpus=1,
             evalue=1e-5,
             max_target_seqs=1,
+            tmpdir=None,
         )
 
     @patch("funannotate2.search.json.dump")
@@ -422,3 +424,71 @@ class TestSearchComprehensive:
         mock_file.assert_any_call("/path/to/db/links_to_ODB.txt", "r")
         mock_file.assert_any_call("output.json", "w")
         mock_file.assert_any_call("annotations.txt", "w")
+
+
+class TestDiamondTmpdirPlumbing:
+    """Tests that --tmpdir is honored end-to-end by the diamond helpers."""
+
+    @patch("funannotate2.search.json_repair.load", return_value=[])
+    @patch("funannotate2.search.open", new_callable=mock_open, create=True)
+    @patch("funannotate2.search.os.remove")
+    @patch("funannotate2.search.os.path.isfile", return_value=True)
+    @patch("funannotate2.search.subprocess.Popen")
+    def test_diamond_blast_uses_provided_tmpdir(
+        self, mock_popen, _mock_isfile, _mock_remove, _mock_open, _mock_load, tmp_path
+    ):
+        """diamond_blast writes its intermediate file into the supplied tmpdir."""
+        proc = MagicMock()
+        proc.communicate.return_value = (b"", b"")
+        mock_popen.return_value = proc
+
+        search.diamond_blast(
+            "db.dmnd", "query.fa", cpus=2, evalue=1e-5, tmpdir=str(tmp_path)
+        )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--out" in cmd
+        out_path = cmd[cmd.index("--out") + 1]
+        assert out_path.startswith(str(tmp_path) + os.sep)
+        assert os.path.basename(out_path).startswith("diamond_")
+
+    @patch("funannotate2.search.json_repair.load", return_value=[])
+    @patch("funannotate2.search.open", new_callable=mock_open, create=True)
+    @patch("funannotate2.search.os.remove")
+    @patch("funannotate2.search.os.path.isfile", return_value=True)
+    @patch("funannotate2.search.subprocess.Popen")
+    def test_diamond_blast_defaults_to_system_tmp(
+        self, mock_popen, _mock_isfile, _mock_remove, _mock_open, _mock_load
+    ):
+        """diamond_blast falls back to tempfile.gettempdir() when tmpdir is None."""
+        import tempfile as _tempfile
+
+        proc = MagicMock()
+        proc.communicate.return_value = (b"", b"")
+        mock_popen.return_value = proc
+
+        search.diamond_blast("db.dmnd", "query.fa")
+
+        cmd = mock_popen.call_args[0][0]
+        out_path = cmd[cmd.index("--out") + 1]
+        assert out_path.startswith(_tempfile.gettempdir() + os.sep)
+
+    @patch("funannotate2.search.env")
+    @patch("funannotate2.search.checkfile", return_value=True)
+    @patch("funannotate2.search.diamond_blast", return_value=[])
+    def test_merops_blast_forwards_tmpdir(
+        self, mock_diamond_blast, _mock_checkfile, mock_env
+    ):
+        mock_env.get.return_value = "/path/to/db"
+        search.merops_blast("q.fa", tmpdir="/scratch/x")
+        assert mock_diamond_blast.call_args.kwargs["tmpdir"] == "/scratch/x"
+
+    @patch("funannotate2.search.env")
+    @patch("funannotate2.search.checkfile", return_value=True)
+    @patch("funannotate2.search.diamond_blast", return_value=[])
+    def test_swissprot_blast_forwards_tmpdir(
+        self, mock_diamond_blast, _mock_checkfile, mock_env
+    ):
+        mock_env.get.return_value = "/path/to/db"
+        search.swissprot_blast("q.fa", tmpdir="/scratch/x")
+        assert mock_diamond_blast.call_args.kwargs["tmpdir"] == "/scratch/x"

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -82,26 +82,55 @@ class TestCreateTmpdir:
     """Tests for the create_tmpdir function."""
 
     def test_create_tmpdir_with_outdir(self, temp_dir):
-        """Test creating a temporary directory with an output directory."""
+        """A unique <base>_<uuid> subdir is created inside the supplied volume."""
         tmpdir = create_tmpdir(temp_dir, base="test")
         assert os.path.exists(tmpdir)
         assert os.path.isdir(tmpdir)
-        assert tmpdir.startswith(os.path.abspath(temp_dir))
+        assert tmpdir.startswith(os.path.abspath(temp_dir) + os.sep)
+        assert os.path.basename(tmpdir).startswith("test_")
+        assert os.path.abspath(tmpdir) != os.path.abspath(temp_dir)
 
     def test_create_tmpdir_with_tmp(self):
-        """Test creating a temporary directory in /tmp."""
+        """Supplying /tmp still yields a unique subdir inside /tmp."""
         tmpdir = create_tmpdir("/tmp", base="test")
-        assert os.path.exists(tmpdir)
-        assert os.path.isdir(tmpdir)
-        assert tmpdir.startswith("/tmp")
+        try:
+            assert os.path.exists(tmpdir)
+            assert os.path.isdir(tmpdir)
+            assert tmpdir.startswith("/tmp" + os.sep)
+            assert os.path.basename(tmpdir).startswith("test_")
+        finally:
+            if os.path.isdir(tmpdir):
+                os.rmdir(tmpdir)
 
     def test_create_tmpdir_without_outdir(self):
-        """Test creating a temporary directory without an output directory."""
+        """With no outdir, a unique subdir is created under tempfile.gettempdir()."""
+        import tempfile as _tempfile
+
         tmpdir = create_tmpdir(None, base="test")
-        assert os.path.exists(tmpdir)
+        try:
+            assert os.path.exists(tmpdir)
+            assert os.path.isdir(tmpdir)
+            assert tmpdir.startswith(
+                os.path.abspath(_tempfile.gettempdir()) + os.sep
+            )
+        finally:
+            if os.path.isdir(tmpdir):
+                os.rmdir(tmpdir)
+
+    def test_create_tmpdir_calls_are_unique(self, temp_dir):
+        """Successive calls with the same parent never collide."""
+        a = create_tmpdir(temp_dir, base="test")
+        b = create_tmpdir(temp_dir, base="test")
+        assert a != b
+        assert os.path.isdir(a)
+        assert os.path.isdir(b)
+
+    def test_create_tmpdir_parent_not_existing(self, temp_dir):
+        """If the supplied parent does not yet exist, it is created along with the subdir."""
+        missing_parent = os.path.join(temp_dir, "does", "not", "exist")
+        tmpdir = create_tmpdir(missing_parent, base="test")
         assert os.path.isdir(tmpdir)
-        # Clean up
-        os.rmdir(tmpdir)
+        assert tmpdir.startswith(os.path.abspath(missing_parent) + os.sep)
 
 
 class TestReadBlocks:


### PR DESCRIPTION
Closes #52.

## Summary

The `--tmpdir` CLI option was not honored for all intermediate files. Two distinct places hard-coded `/tmp`, causing `FileNotFoundError` on nodes where `/tmp` is not writable (HPC/slurm, containers) even when the user supplied `--tmpdir`.

This PR threads the user-supplied tmp directory end-to-end through both the `annotate` diamond searches and the `predict` miniprot alignment, and makes `create_tmpdir` robust against accidental deletion of a user-supplied volume.

## Root cause

### 1. `annotate` → `swissprot_blast` / `merops_blast` → `diamond_blast`
`diamond_blast` defaulted to `tmpdir="/tmp"` and its two wrappers did not accept a `tmpdir` kwarg at all. `annotate.py` never forwarded `args.tmpdir`, so diamond intermediates were always written to `/tmp/diamond_<uuid>` — exactly the traceback in #52.

### 2. `predict` → `align_proteins`
`align_proteins` defaulted to `tmpdir="/tmp"` and wrote `mini_tmp = os.path.join(tmpdir, f"{uuid.uuid1()}.miniprot.out")`. `predict.py` never passed a `tmpdir`, so miniprot output hit `/tmp` regardless of `--tmpdir`. Same class of bug, different tool.

### 3. `create_tmpdir` semantics
When the user passed any `--tmpdir` other than `/tmp`, `create_tmpdir` returned the directory **verbatim** — meaning the downstream `shutil.rmtree(tmp_dir)` in `predict.py` would wipe the user-supplied volume. It also blocked concurrent runs sharing a scratch volume.

## Changes

**`funannotate2/search.py`**
- `diamond_blast(..., tmpdir="/tmp")` → `diamond_blast(..., tmpdir=None)` with fallback to `tempfile.gettempdir()` (honors `$TMPDIR`).
- `swissprot_blast(..., tmpdir=None)` and `merops_blast(..., tmpdir=None)` — new kwarg, forwarded to `diamond_blast`.

**`funannotate2/annotate.py`**
- `swissprot_blast(Proteins, cpus=args.cpus)` → `swissprot_blast(Proteins, cpus=args.cpus, tmpdir=tmp_dir)`.
- `merops_blast(Proteins, cpus=args.cpus)` → `merops_blast(Proteins, cpus=args.cpus, tmpdir=tmp_dir)`.

**`funannotate2/align.py`**
- Added `import tempfile`.
- `align_proteins(..., tmpdir="/tmp")` → `align_proteins(..., tmpdir=None)` with fallback to `tempfile.gettempdir()`.
- `align_transcripts(..., tmpdir="/tmp")` → `align_transcripts(..., tmpdir=None)` for API parity (kwarg was and remains unused internally — gapmm2 writes directly to `output=evidence`; docstring updated to explain).

**`funannotate2/predict.py`**
- Pass `tmpdir=tmp_dir` to both `align_transcripts(...)` and `align_proteins(...)`.

**`funannotate2/utilities.py`**
- `create_tmpdir` now **always** creates a unique `<base>_<uuid>` subdirectory inside the supplied volume (previously only for `/tmp`). Falls back to `tempfile.gettempdir()` when no volume is supplied (was CWD). This prevents the `shutil.rmtree` hazard on user-supplied volumes and makes concurrent runs safe on a shared scratch directory.

## Behavior change for users
- `funannotate2 annotate --tmpdir /scratch/mydir` now writes `/scratch/mydir/<base>_<uuid>/...` — previously it would write directly into `/scratch/mydir` and could later delete it.
- When `--tmpdir` is omitted, temporary files now land in `tempfile.gettempdir()` (which honors `$TMPDIR`), not a hardcoded `/tmp`.

## Tests

All new tests extend existing test modules — no new test files created.

- `tests/unit/test_utilities.py::TestCreateTmpdir` — 5 tests covering unique-subdir creation, absolute paths, `$TMPDIR` fallback, and subdir isolation from the user-supplied volume.
- `tests/unit/test_search_comprehensive.py::TestDiamondTmpdirPlumbing` — 4 new tests that mock `subprocess.Popen` and assert diamond's `--out` argument is under the caller-supplied tmpdir; plus two existing assertions updated for the new `tmpdir=None` kwarg on `swissprot_blast`/`merops_blast`.
- `tests/unit/test_predict.py::TestAlignProteinsTmpdir` — 2 new tests that mock `runSubprocess` and assert the `stdout` path passed to miniprot is inside the caller-supplied tmpdir (explicit case) or inside `tempfile.gettempdir()` (fallback case).

### Results

```
$ pytest tests/unit/test_utilities.py tests/unit/test_search_comprehensive.py tests/unit/test_predict.py -q
... 41 passed

$ pytest tests/ -q
196 passed, 2 failed, 61 skipped
```

The 2 failures (`test_funannotate_cli::test_version_command`, `test_help_command`) are pre-existing environment-specific failures — `subprocess.run("python -m funannotate2 --version")` returns 127 in the integration harness on this machine. Verified identical on `git stash` (before any change in this PR).

## Non-goals / out of scope
- `abinitio.py`'s `folder="/tmp"` kwargs — these wrap work in `tempfile.TemporaryDirectory()` internally, so `$TMPDIR` is already honored at runtime. Stylistic cleanup only; left for a separate change.
- `evm.py::evm_consensus` has a `tmpdir="/tmp"` default but is not imported or called anywhere else in the package (dead code).
- Changing gapmm2 behavior to actually consume the `tmpdir` kwarg — gapmm2 writes directly to the caller-supplied `output` path; a staging tmp is out of scope.

## Rollback
All changes are confined to `funannotate2/{search,annotate,align,predict,utilities}.py` and three existing unit-test modules. All added kwargs default to `None`, so the public API is backwards compatible.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author