### PR TITLE
Suppress repetitive GeneMark license banner in training/predict logs

### DIFF
--- a/funannotate2/abinitio.py
+++ b/funannotate2/abinitio.py
@@ -29,6 +29,54 @@ from .utilities import (
 )
 
 
+# Track whether the gmhmme3 license banner has been logged this run.
+# gmhmme3 prints a multi-line banner to both stdout and stderr on every
+# invocation, which pollutes the log file when called once per contig.
+_GENEMARK_BANNER_LOGGED = False
+
+_GENEMARK_BANNER_MARKERS = (
+    "GeneMark.hmm eukaryotic",
+    "days remaining in the license period",
+)
+
+
+def _genemark_output_filter(log, stdout, stderr):
+    """runSubprocess output_filter for gmhmme3.
+
+    Logs the license banner at most once per Python process; forwards any
+    other (non-banner) content to log.debug so real warnings/errors are kept.
+    """
+    global _GENEMARK_BANNER_LOGGED
+
+    def split_banner(text):
+        if not text:
+            return "", ""
+        banner_lines = []
+        other_lines = []
+        for line in text.splitlines():
+            if any(m in line for m in _GENEMARK_BANNER_MARKERS):
+                banner_lines.append(line)
+            else:
+                other_lines.append(line)
+        return "\n".join(banner_lines), "\n".join(l for l in other_lines if l.strip())
+
+    out_banner, out_other = split_banner(stdout)
+    err_banner, err_other = split_banner(stderr)
+
+    if not _GENEMARK_BANNER_LOGGED:
+        banner = out_banner or err_banner
+        if banner and hasattr(log, "debug"):
+            log.debug(banner)
+        if banner:
+            _GENEMARK_BANNER_LOGGED = True
+
+    if hasattr(log, "debug"):
+        if out_other:
+            log.debug(out_other)
+        if err_other:
+            log.debug(err_other)
+
+
 class reversor:
     def __init__(self, obj):
         self.obj = obj
@@ -1637,6 +1685,7 @@ def run_genemark(
         cwd=workdir,
         monitor_memory=True,
         process_name=f"genemark-{os.path.basename(genome)}",
+        output_filter=_genemark_output_filter,
     )
     Genes = gtf2dict(os.path.join(workdir, tmpout), genome)
     Cleaned = {}
@@ -3211,7 +3260,12 @@ def test_training(
                 os.path.basename(c) + ".gtf",
                 os.path.basename(c),
             ]
-            runSubprocess(cmd, log, cwd=os.path.join(tmpdir, "test"))
+            runSubprocess(
+                cmd,
+                log,
+                cwd=os.path.join(tmpdir, "test"),
+                output_filter=_genemark_output_filter,
+            )
             if checkfile(g_out):
                 with open(g_out) as infile:
                     for line in infile:

--- a/funannotate2/utilities.py
+++ b/funannotate2/utilities.py
@@ -704,6 +704,7 @@ def runSubprocess(
     env=False,
     monitor_memory=False,
     process_name=None,
+    output_filter=None,
 ):
     """
     Run a command using subprocess and direct output and stderr.
@@ -823,7 +824,9 @@ def runSubprocess(
 
         if not only_failed:
             # Handle different logger types for output logging
-            if hasattr(logfile, "debug"):
+            if output_filter is not None:
+                output_filter(logfile, process.stdout, process.stderr)
+            elif hasattr(logfile, "debug"):
                 logoutput(logfile.debug, process)
             elif callable(logfile):
                 # For function-based loggers, skip detailed output logging


### PR DESCRIPTION
## Problem

During `funannotate2 train` (and `predict`), `gmhmme3` is invoked once per contig. Each invocation prints a two-line license banner to both stdout and stderr:

```
GeneMark.hmm eukaryotic 3
16 days remaining in the license period.
```

`runSubprocess` captures both streams and forwards them to `logger.debug(...)`, and the file handler is set to `DEBUG`. Result: the log file gets flooded with duplicate banners (one block per contig — typically dozens to thousands).

Example from a user's log:
```
[Apr 22 08:53 AM] gmhmme3 -f gtf -k 0.03 -m gmhmm.mod -o g_272.fa.gtf g_272.fa
[Apr 22 08:53 AM] GeneMark.hmm eukaryotic 3
16 days remaining in the license period.

GeneMark.hmm eukaryotic 3
16 days remaining in the license period.

[Apr 22 08:53 AM] gmhmme3 -f gtf -k 0.03 -m gmhmm.mod -o g_947.fa.gtf g_947.fa
...
```

## Fix

1. **`funannotate2/utilities.py`** — add an opt-in `output_filter=None` kwarg to `runSubprocess`. When set, the success path delegates output handling to `output_filter(logfile, stdout, stderr)` instead of the default `logoutput(logfile.debug, process)`. Default behavior is unchanged for every existing caller. Error path (`CalledProcessError`) is untouched.

2. **`funannotate2/abinitio.py`** — add a module-level `_GENEMARK_BANNER_LOGGED` flag and a `_genemark_output_filter` helper. The helper splits each stream into banner lines (matching `GeneMark.hmm eukaryotic` or `days remaining in the license period`) vs. other content; the banner is logged at `debug` once per process, then suppressed on subsequent calls. Non-banner content (real warnings/errors) continues to go through `log.debug`. Both `gmhmme3` call sites (`run_genemark` and the evaluation loop's `tool == "genemark"` branch) now pass `output_filter=_genemark_output_filter`.

## Preserved behavior

- The per-contig `gmhmme3 -f gtf -k 0.03 ...` command line is still logged (that one is useful for debugging; only the banner is suppressed).
- Any non-banner gmhmme3 output (real warnings/errors) is still logged at debug.
- Command failures (`CalledProcessError`) still log full stdout/stderr at error level — unchanged.
- No behavioral change for Augustus / SNAP / GlimmerHMM / BUSCO or any other tool.

## Verification

- `python3 -m py_compile funannotate2/utilities.py funannotate2/abinitio.py` — both compile clean.
- Ad-hoc behavior test against a stub logger:
  - First call with banner content → 1 debug emission, flag flips to `True`.
  - Second identical call → still 1 (banner suppressed).
  - Third call with banner + extra content → 3 (banner still not re-emitted, non-banner lines forwarded).
  - Empty / `None` inputs handled without raising.

## Risk notes

- Module-level flag lives for the Python process. Current call sites are serial per-contig in the main process. If a future caller moves `gmhmme3` into a `multiprocessing` worker (fork), each worker would log the banner once — still a massive reduction.
- Banner detection is substring-based. If GeneMark ever changes the banner wording significantly, a new line would fall through to normal debug logging (degrades to current behavior — non-fatal).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author