### PR TITLE
Fix pytantan build error by disabling SIMD instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git build-essential cmake zlib1g-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-RUN SKBUILD_CMAKE_ARGS="-DHAVE_AVX2:BOOL=OFF;-DAVX2_C_FLAGS:STRING=" \
+RUN CMAKE_ARGS="-DHAVE_AVX2=OFF -DAVX2_C_FLAGS= -DHAVE_SSE4=OFF -DSSE4_C_FLAGS= -DHAVE_NEON=OFF -DNEON_C_FLAGS=" \
     /app/.pixi/envs/default/bin/pip install --no-deps --force-reinstall \
         "pytantan @ git+https://github.com/althonos/pytantan.git@v${PYTANTAN_VERSION}" && \
     rm -rf /root/.cache/pip


### PR DESCRIPTION
Fixes the `Illegal instruction` error when running the funannotate2 Docker image on Rosetta 2 or other CPUs lacking AVX2 instructions by correctly passing the CMake arguments needed to disable SIMD instructions in `pytantan` during build. `scikit-build-core` uses `CMAKE_ARGS` instead of `SKBUILD_CMAKE_ARGS` which is why the previous command was silently ignored.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author