### PR TITLE
fix: repair CITATION.cff and clarify BAM contig-map comment

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: version = "26.5.22"
+cff-version: 1.2.0
 title: 'funannotate2: eukaryotic genome annotation'
 message: >-
   If you use this software, please cite it using the
@@ -17,5 +17,5 @@ keywords:
   - functional annotation
   - consensus gene models
 license: BSD-2-Clause
-version: version = "26.5.22"
+version: 26.5.22
 date-released: '2026-05-24'

--- a/funannotate2/predict.py
+++ b/funannotate2/predict.py
@@ -205,7 +205,11 @@ def predict(args):
     contig_name_map = simplify_headers_drop(
         args.fasta, GenomeFasta, GenomeMito, drop=list(mito_contigs.keys())
     )
-    # Create inverse contig map for BAM processing (maps simplified names back to original)
+    # Build the BAM->simplified contig map for annorefine.bam2hints. The BAM
+    # file references the user's original contig names, but everything
+    # downstream (per-contig FASTAs, hints files) uses the simplified names
+    # produced by simplify_headers_drop, so we need {original: simplified}.
+    # contig_name_map is {simplified: original}, so invert it here.
     inv_contig_map = {value: key for key, value in contig_name_map.items()}
     maskedRegions = os.path.join(misc_dir, "softmasked-regions.bed")
     asmGaps = os.path.join(misc_dir, "assembly-gaps.bed")


### PR DESCRIPTION
## Summary

Two small fixes surfaced during a pre-tag code review:

1. **`CITATION.cff` is malformed.** Both `cff-version` and `version` were
   set to the literal string `version = "26.5.22"` (looks like a sed
   substitution that grabbed too much). The file does not validate as
   CFF, so GitHub's "Cite this repository" widget, `cffconvert`, and any
   DOI/Zenodo integration would reject it.

   Fixed to:
   - `cff-version: 1.2.0` (CFF schema version)
   - `version: 26.5.22` (matches `pyproject.toml`)

   Verified with `cffconvert --validate` (schema 1.2.0) and a sample
   BibTeX render.

2. **Misleading comment on `inv_contig_map` in `predict.py`.** The inline
   comment claimed it "maps simplified names back to original", but the
   dict comprehension inverts `{simplified: original}` into
   `{original: simplified}` — the opposite direction.

   The runtime usage is correct (it matches `annorefine.bam2hints`'
   `contig_map` contract: keys are input/BAM contig names, values are
   output/hint contig names), but the comment misled anyone tracing the
   BAM hint path. Replaced with an accurate description of why the
   inversion is needed.

No behavior change in either commit.

## Why now

These were flagged as the two blocking items in a pre-tag review of
`v2025.11.1..main`. With these in, the codebase looks ready for a new
tag.

## Test plan

- `pixi run pytest tests/unit` — 152 passed, 35 skipped.
- `cffconvert --validate -i CITATION.cff` → "Citation metadata are
  valid according to schema version 1.2.0."
- `cffconvert -i CITATION.cff -f bibtex` renders without errors.
