### PR TITLE
build: release 2026.6.9 (+ fix CITATION pre-commit hook portability)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,21 +3,25 @@
 
 # Check if pyproject.toml is being modified
 if git diff --cached --name-only | grep -q "pyproject.toml"; then
-    # Extract the version from pyproject.toml
-    VERSION=$(grep -E 'version\s*=\s*"[^"]+"' pyproject.toml | head -1 | sed -E 's/.*version\s*=\s*"([^"]+)".*/\1/')
-    
+    # Extract the version from pyproject.toml.
+    # Use [[:space:]] instead of \s so the regex works on both GNU and BSD
+    # (macOS) grep/sed — BSD treats \s as a literal 's', which silently
+    # falls back to capturing the whole line and corrupts CITATION.cff.
+    VERSION=$(grep -E '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[^"]+"' pyproject.toml | head -1 | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+
     if [ -n "$VERSION" ]; then
         # Get current date in YYYY-MM-DD format
         TODAY=$(date +"%Y-%m-%d")
-        
-        # Update version and date in CITATION.cff
-        sed -i.bak -E "s/version: .*/version: $VERSION/" CITATION.cff
-        sed -i.bak -E "s/date-released: .*/date-released: '$TODAY'/" CITATION.cff
+
+        # Update version and date in CITATION.cff. Anchor with ^ so the
+        # `version:` rule does not also clobber the `cff-version:` line.
+        sed -i.bak -E "s/^version: .*/version: $VERSION/" CITATION.cff
+        sed -i.bak -E "s/^date-released: .*/date-released: '$TODAY'/" CITATION.cff
         rm CITATION.cff.bak
-        
+
         # Add the updated CITATION.cff to the commit
         git add CITATION.cff
-        
+
         echo "Updated CITATION.cff to version $VERSION and date $TODAY"
     fi
 fi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,5 +17,5 @@ keywords:
   - functional annotation
   - consensus gene models
 license: BSD-2-Clause
-version: 26.5.22
-date-released: '2026-05-24'
+version: 2026.6.9
+date-released: '2026-06-09'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "funannotate2"
-version = "26.5.22"
+version = "2026.6.9"
 description = "Funannotate2: eukarytoic genome annotation pipeline"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [


### PR DESCRIPTION
## Summary

Release cut for **`2026.6.9`** (today). Two commits:

1. **`fix(hooks): make pre-commit CITATION sync portable`** — The
   `.githooks/pre-commit` hook auto-updates `CITATION.cff` whenever
   `pyproject.toml` changes, but two bugs caused it to silently corrupt
   the file on macOS/BSD:
   - The version-extraction regex used `\s` (GNU-only) in `grep -E` /
     `sed -E`. On BSD this matches a literal `s`, so the capture fails
     and `VERSION` falls back to the entire matched line
     (`version = "X.Y.Z"`).
   - The CITATION substitution `s/version: .*/.../` was unanchored,
     so it also rewrote the `cff-version:` line.

   Together these produced the malformed CFF that #73 had to repair.
   Fix is `[[:space:]]` instead of `\s` and `^`-anchored substitutions.

2. **`build: bump version to 2026.6.9`** — `pyproject.toml` and
   `CITATION.cff` bumped from `26.5.22` to `2026.6.9`, matching the
   CalVer (`YYYY.M.D`) form of the prior `v2025.11.1` tag.

## Test plan

- `cffconvert --validate -i CITATION.cff` → valid against schema 1.2.0.
- Ran the fixed hook locally against the new `pyproject.toml`; it
  extracted `2026.6.9` correctly and updated only the `version:` and
  `date-released:` lines (cff-version line untouched).

## Follow-up

Once merged, I'll tag `v2026.6.9` on `main` to trigger
`production-release.yml` and `docker.yml`.
